### PR TITLE
Add Projects page to website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,6 +41,7 @@ menu = [
     { name = "Posters", url = "/posters", weight = 2 },
     { name = "Services", url = "/phd-activities", weight = 3 },
     { name = "Talks", url = "/talks", weight = 4 },
+    { name = "Projects", url = "/projects", weight = 5 },
 ]
 
 stylesheets = [

--- a/content/projects.md
+++ b/content/projects.md
@@ -1,0 +1,18 @@
++++
+title = "Projects"
+template = "simple-markdown.html"
++++
+
+## Currently Maintaining
+
+### maven-lockfile
+
+Lockfile support for Maven projects. It lets you pin your exact dependency tree and verify it on every build, making your builds reproducible and protecting against supply-chain tampering.
+
+[GitHub](https://github.com/chains-project/maven-lockfile)
+
+### mcp-drift
+
+A tool that detects drift in MCP (Model Context Protocol) server tool definitions — catching unannounced changes to the tools an MCP server exposes.
+
+[GitHub](https://github.com/algomaster99/mcp-drift)


### PR DESCRIPTION
## Summary
This PR adds a new Projects page to the website that showcases currently maintained projects.

## Changes
- **New page**: Created `content/projects.md` with a "Currently Maintaining" section featuring two projects:
  - `maven-lockfile`: A tool providing lockfile support for Maven projects to ensure reproducible builds and protect against supply-chain tampering
  - `mcp-drift`: A tool that detects drift in MCP server tool definitions
- **Navigation**: Updated `config.toml` to add a "Projects" menu item to the main navigation with weight 5

## Details
The new Projects page uses the `simple-markdown.html` template and includes links to the GitHub repositories for each project. The menu item is positioned after "Talks" in the navigation hierarchy.

https://claude.ai/code/session_01EqR6ZJn5mLsJKUNrjcgDtP